### PR TITLE
Fixed setting up link in RaidBuffs-Repo-README.md

### DIFF
--- a/Triggernometry/README/RaidBuffs-Repo-README.md
+++ b/Triggernometry/README/RaidBuffs-Repo-README.md
@@ -19,7 +19,7 @@ In case you are wondering how to install this :
 
 > Select `Aho's Raid Buffs` > BOTTOM LEFT > `Add Selected`  
 
-Congrats, you have it installed. Now, on to [Setting Up](#Setup)  
+Congrats, you have it installed. Now, on to [Setting Up](#setting-up)  
 ## Setting Up
 ### # Setting up from in-game
 Q. Why would i want to do this ?  


### PR DESCRIPTION
Fixed the "Setting Up" link to correctly link to the setting up section of the page.